### PR TITLE
fix: small bug when calling the schedulers when we switched to manual optimization

### DIFF
--- a/hfgl/model.py
+++ b/hfgl/model.py
@@ -765,7 +765,9 @@ class HiFiGAN(pl.LightningModule):
                 optim_d, gradient_clip_val=1.0, gradient_clip_algorithm="norm"
             )
             optim_d.step()
-            scheduler_d.step()
+            # step in the scheduler every epoch
+            if self.trainer.is_last_batch:
+                scheduler_d.step()
             # log discriminator loss
             self.log("training/disc/d_loss_total", disc_loss_total, prog_bar=False)
 
@@ -795,7 +797,9 @@ class HiFiGAN(pl.LightningModule):
             optim_d, gradient_clip_val=1.0, gradient_clip_algorithm="norm"
         )
         optim_g.step()
-        scheduler_g.step()
+        # step in the scheduler every epoch
+        if self.trainer.is_last_batch:
+            scheduler_g.step()
         # log generator loss
         self.log("training/gen/gen_loss_total", gen_loss_total, prog_bar=False)
         self.log("training/gen/mel_spec_error", loss_mel / 45, prog_bar=False)


### PR DESCRIPTION
We were calling `scheduler_d.step()` and `scheduler_g.step()` at every step, but the schedulers we are using should be called at every epoch (this is consistent with the original [HiFiGAN implementation](https://github.com/jik876/hifi-gan/blob/4769534d45265d52a904b850da5a622601885777/train.py#L220C2-L220C3)). Since the schedulers were called at each step the learning rate quickly became really small and there was no learning.