### PR TITLE
refactor: use Python 3.10 style typing for unions and basic types

### DIFF
--- a/hfgl/cli.py
+++ b/hfgl/cli.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from pathlib import Path
-from typing import List
 
 import typer
 from everyvoice.base_cli.interfaces import (
@@ -24,7 +23,7 @@ class PreprocessCategories(str, Enum):
 @app.command()
 @merge_args(preprocess_base_command_interface)
 def preprocess(
-    steps: List[PreprocessCategories] = typer.Option(
+    steps: list[PreprocessCategories] = typer.Option(
         [cat.value for cat in PreprocessCategories],
         "-s",
         "--steps",

--- a/hfgl/config/__init__.py
+++ b/hfgl/config/__init__.py
@@ -1,7 +1,7 @@
 import math
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional
 
 from everyvoice.config.preprocessing_config import PreprocessingConfig
 from everyvoice.config.shared_types import (
@@ -37,11 +37,11 @@ class HiFiGANModelConfig(ConfigModel):
         HiFiGANResblock.one,
         description="Which resblock to use. See Kong et. al. 2020: https://arxiv.org/abs/2010.05646",
     )
-    upsample_rates: List[int] = Field(
+    upsample_rates: list[int] = Field(
         [8, 8],
         description="The stride of each convolutional layer in the upsampling module.",
     )
-    upsample_kernel_sizes: List[int] = Field(
+    upsample_kernel_sizes: list[int] = Field(
         [16, 16],
         description="The kernel size of each convolutional layer in the upsampling module.",
     )
@@ -49,11 +49,11 @@ class HiFiGANModelConfig(ConfigModel):
         512,
         description="The number of dimensions to project the Mel inputs to before being passed to the resblock.",
     )
-    resblock_kernel_sizes: List[int] = Field(
+    resblock_kernel_sizes: list[int] = Field(
         [3, 7, 11],
         description="The kernel size of each convolutional layer in the resblock.",
     )
-    resblock_dilation_sizes: List[List[int]] = Field(
+    resblock_dilation_sizes: list[list[int]] = Field(
         [[1, 3, 5], [1, 3, 5], [1, 3, 5]],
         description="The dilations of each convolution in each layer of the resblock.",
     )
@@ -67,7 +67,7 @@ class HiFiGANModelConfig(ConfigModel):
     msd_layers: int = Field(
         3, description="The number of layers to use in the Multi-Scale Discriminator."
     )
-    mpd_layers: List[int] = Field(
+    mpd_layers: list[int] = Field(
         [2, 3, 5, 7, 11],
         description="The size of each layer in the Multi-Period Discriminator.",
     )
@@ -82,7 +82,7 @@ class HiFiGANTrainingConfig(BaseTrainingConfig):
         HiFiGANTrainTypes.original,
         description="The type of GAN to use. Can be set to either 'original' for a vanilla GAN, or 'wgan' for a Wasserstein GAN that clips gradients.",
     )
-    optimizer: Union[AdamOptimizer, AdamWOptimizer, RMSOptimizer] = Field(
+    optimizer: AdamOptimizer | AdamWOptimizer | RMSOptimizer = Field(
         default_factory=AdamWOptimizer,
         description="Configuration settings for the optimizer.",
     )
@@ -123,7 +123,7 @@ class HiFiGANConfig(PartialLoadConfig):
     )
 
     @model_validator(mode="before")  # type: ignore
-    def load_partials(self: Dict[Any, Any], info: ValidationInfo):
+    def load_partials(self: dict[Any, Any], info: ValidationInfo):
         config_path = (
             info.context.get("config_path", None) if info.context is not None else None
         )

--- a/hfgl/model.py
+++ b/hfgl/model.py
@@ -1,6 +1,5 @@
 import itertools
 import math
-from typing import Dict, Union
 
 import pytorch_lightning as pl
 import torch
@@ -441,7 +440,7 @@ class MultiScaleDiscriminator(torch.nn.Module):
 
 
 class HiFiGAN(pl.LightningModule):
-    def __init__(self, config: Union[Dict, VocoderConfig]):
+    def __init__(self, config: dict | VocoderConfig):
         super().__init__()
         self.automatic_optimization = False
         # Because we serialize the configurations when saving checkpoints,
@@ -452,9 +451,9 @@ class HiFiGAN(pl.LightningModule):
         self.mpd = MultiPeriodDiscriminator(config)
         self.msd = MultiScaleDiscriminator(config)
         self.generator = Generator(config)
-        self.batch_size = (
-            self.config.training.batch_size
-        )  # this is declared explicitly so that auto_scale_batch_size works: https://pytorch-lightning.readthedocs.io/en/stable/advanced/training_tricks.html
+        # batch_size is declared explicitly so that auto_scale_batch_size works:
+        # https://pytorch-lightning.readthedocs.io/en/stable/advanced/training_tricks.html
+        self.batch_size = self.config.training.batch_size
         self.save_hyperparameters()  # TODO: ignore=['specific keys'] - I should ignore some unnecessary/problem values
         self.audio_config = config.preprocessing.audio
         self.sampling_rate_change = (
@@ -548,7 +547,8 @@ class HiFiGAN(pl.LightningModule):
             )
         else:
             scheduler_g = torch.optim.lr_scheduler.ExponentialLR(
-                optim_g, gamma=0.999  # TODO: parametrize this
+                optim_g,
+                gamma=0.999,  # TODO: parametrize this
             )
             scheduler_d = torch.optim.lr_scheduler.ExponentialLR(optim_d, gamma=0.999)
             return [optim_g, optim_d], [scheduler_g, scheduler_d]


### PR DESCRIPTION
Since Python 3.10, we can use A | B instead of Union[A, B]

Since Python 3.9, typing.List, .Dict, .Tuple, .Set etc are deprecated because the builtin types now support indexing.

I think it's now finally safe to do this wider refactoring, not just bump the Python version