### PR TITLE
fix: enum should derive from str if we want to compare them to string

### DIFF
--- a/hfgl/config/__init__.py
+++ b/hfgl/config/__init__.py
@@ -21,12 +21,29 @@ from everyvoice.utils import (
 from pydantic import Field, FilePath, ValidationInfo, model_validator
 
 
-class HiFiGANResblock(Enum):
+# NOTE: We need to derive from both str and Enum if we want `HiFiGANResblock.one == "one"` to be True.
+#    Otherwise, `HiFiGANResblock.one == "one"` will be false.
+#    [Python Enum Comparisons](https://docs.python.org/3/howto/enum.html#comparisons)
+#    Comparisons against non-enumeration values will always compare not equal.
+#    In [1]: from enum import Enum
+#    In [2]: class A(Enum):
+#       ...:     a = "a"
+#       ...:     b = "b"
+#       ...:
+#    In [3]: A.a == "a"
+#    Out[3]: False
+#    In [4]: class S(str, Enum):
+#       ...:     a = "a"
+#       ...:     b = "b"
+#       ...:
+#    In [5]: S.a == "a"
+#    Out[5]: True
+class HiFiGANResblock(str, Enum):
     one = "1"
     two = "2"
 
 
-class HiFiGANTrainTypes(Enum):
+class HiFiGANTrainTypes(str, Enum):
     original = "original"
     wgan = "wgan"
     # wgan_gp = "wgan-gp"


### PR DESCRIPTION
Fix where programmatically writing a HiFiGAN then reloading the model for a unittest would fail.  There were hints that the model was saved using `ResBlock1` but when it was reloaded the model was instantiate with `ResBlock2` thus the matrices' names were not correct.

# Error
 The unittest was reporting the following error message.  Note that the missing keys are for `ResBlock1` because of `convs1` while the `unexpected key(s)` are for `ResBlock2` as hinted by `convs`.
```
RuntimeError: Error(s) in loading state_dict for HiFiGAN:
        Missing key(s) in state_dict: "generator.resblocks.0.convs1.0.bias", "generator.resblocks.0.convs1.0.weight_g"
...
Unexpected key(s) in state_dict: "generator.resblocks.0.convs.0.bias", "generator.resblocks.0.convs.0.weight_g"
```

While tracing the code, the following code `resblock = ResBlock1 if self.model_vocoder_config.resblock == "1" else ResBlock2` in `HiFiGAN_iSTFT_lightning > hfgl > model.py > Generator`, I noticed that `self.model_vocoder_config.resblock` was of type `HiFiGANResBlock` defined as `class HiFiGANResBlock(Enum)` and when comparing `self.model_vocoder_config.resblock == "1"` would ALWAYS return `False` as stated in the doc (see the NOTES section).


# Traces

The initial in memory config:
```python
config=HiFiGANConfig(contact=ContactInformation(contact_name='Test Runner', contact_email='info@ev
eryvoice.ca'), model=HiFiGANModelConfig(resblock=<HiFiGANResblock.one: '1'> ...
```

The initial in memory `HiFiGAN` showing `ResBlock1`
```python
vocoder=HiFiGAN(
...
  (generator): Generator(
    (conv_pre): Conv1d(80, 512, kernel_size=(7,), stride=(1,), padding=(3,))
    (ups): ModuleList(
      (0): ConvTranspose1d(512, 256, kernel_size=(16,), stride=(8,), padding=(4,))
      (1): ConvTranspose1d(256, 128, kernel_size=(16,), stride=(8,), padding=(4,))
    )
    (resblocks): ModuleList(
      (0): ResBlock1(
        (convs1): ModuleList(
          (0): Conv1d(256, 256, kernel_size=(3,), stride=(1,), padding=(1,))
          (1): Conv1d(256, 256, kernel_size=(3,), stride=(1,), padding=(3,), dilation=(3,))
          (2): Conv1d(256, 256, kernel_size=(3,), stride=(1,), padding=(5,), dilation=(5,))
        )
        (convs2): ModuleList(
          (0-2): 3 x Conv1d(256, 256, kernel_size=(3,), stride=(1,), padding=(1,))
        )
      )
```

Config after reloading it from the checkpoint.  `resblock` is no longer a `HiFiGANResblock` but rather a simple `str`.
```python
vocoder_config=HiFiGANConfig(contact=ContactInformation(contact_name='Test Runner'
, contact_email='info@everyvoice.ca'), model=HiFiGANModelConfig(resblock='1', ...
```

```
model=HiFiGAN(
...
  (generator): Generator(
    (conv_pre): Conv1d(80, 512, kernel_size=(7,), stride=(1,), padding=(3,))
    (ups): ModuleList(
      (0): ConvTranspose1d(512, 256, kernel_size=(16,), stride=(8,), padding=(4,))
      (1): ConvTranspose1d(256, 128, kernel_size=(16,), stride=(8,), padding=(4,))
    )
    (resblocks): ModuleList(
      (0): ResBlock2(
        (convs): ModuleList(
          (0): Conv1d(256, 256, kernel_size=(3,), stride=(1,), padding=(1,))
          (1): Conv1d(256, 256, kernel_size=(3,), stride=(1,), padding=(3,), dilation=(3,))
        )
      )
```

# NOTES

We need to derive from both str and Enum if we want `HiFiGANResblock.one == "one"` to be True.
Otherwise, `HiFiGANResblock.one == "one"` will be false.

[Python Enum Comparisons](https://docs.python.org/3/howto/enum.html#comparisons)
Comparisons against non-enumeration values will always compare not equal.

```python
In [1]: from enum import Enum
In [2]: class A(Enum):
   a = "a"
   b = "b"

 In [3]: A.a == "a"
   Out[3]: False
In [4]: class S(str, Enum):
  a = "a"
  b = "b"

In [5]: S.a == "a"
  Out[5]: True
```