### PR TITLE
feat: add export option to remove discriminators

### DIFF
--- a/hfgl/cli.py
+++ b/hfgl/cli.py
@@ -67,7 +67,6 @@ def train(**kwargs):
 @app.command()
 def export(
     model_path: Path = typer.Argument(
-        None,
         exists=True,
         dir_okay=False,
         file_okay=True,


### PR DESCRIPTION
allow synthesis with only the generator checkpoint

fixes https://github.com/EveryVoiceTTS/EveryVoice/issues/424

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

This PR allows users to "export" vocoder models (`everyvoice export`) which trims down the model by removing the discriminators. It also allows loading the vocoder model and inference/synthesis (not training) using only the generator. This allows us to distribute 50MB files instead of 950MB files when all people want to do is synthesize (not fine-tune/resume training)

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

https://github.com/EveryVoiceTTS/EveryVoice/issues/424

### Feedback sought? <!-- What should reviewers focus on in particular? -->

sanitty

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high - [v0.1.0a4](https://github.com/EveryVoiceTTS/EveryVoice/milestone/4)

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

Again, we do not have tests for inference unfortunately

### How to test? <!-- Explain how reviewers should test this PR. -->

take an existing vocoder and run `everyvoice export <path_to_vocoder.ckpt>` then try synthesizing using the generated `exported.ckpt` checkpoint.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium-high

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

yes, [v0.1.0a4](https://github.com/EveryVoiceTTS/EveryVoice/milestone/4)

### Related PRs? <!-- Parent Everyvoice PR or other submodule PRs required for this PR to make sense. -->

https://github.com/EveryVoiceTTS/EveryVoice/pull/552

<!-- Add any other relevant information here -->
