### PR TITLE
Dev.ej/repo maintenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/hfgl/__main__.py
+++ b/hfgl/__main__.py
@@ -1,0 +1,10 @@
+"""
+This file turns the package into a module that can be run as a script with
+    python -m hfgl ...
+or, for coverage analysis, with
+    coverage run -m hfgl ...
+"""
+
+from .cli import app
+
+app()


### PR DESCRIPTION
Update pre-commit config to our current standard in EV.
Add `__main__.py` in each module to enable calling each app with `coverage run`.